### PR TITLE
feat: 소셜 로그인 access 토큰 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.1'
+	//id 'org.springframework.boot' version '4.0.1'
+    id 'org.springframework.boot' version '3.4.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -27,7 +28,8 @@ repositories {
 dependencies {
 	// Database & JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-flyway'
+	//implementation 'org.springframework.boot:spring-boot-starter-flyway'
+    implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -42,12 +44,22 @@ dependencies {
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+	//testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Swagger (SpringDoc)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    // WebClient용 (외부 API 호출)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+    // Java 17+ 환경에서 JWT 0.9.1 실행 시 필수 (없으면 로그인 에러)
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/symteo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/symteo/domain/auth/controller/AuthController.java
@@ -1,0 +1,42 @@
+package com.symteo.domain.auth.controller;
+
+import com.symteo.domain.auth.dto.AuthResponse;
+import com.symteo.domain.auth.dto.LoginRequest;
+import com.symteo.domain.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    // 1. 소셜 로그인 (가입/로그인 통합)
+    // URL: POST /api/v1/auth/login/kakao (또는 naver, google)
+    @PostMapping("/login/{provider}")
+    public ResponseEntity<AuthResponse> login(
+            @PathVariable String provider,
+            @RequestBody LoginRequest request // { "token": "소셜_액세스_토큰" }
+    ) {
+        AuthResponse response = authService.login(provider, request.getToken());
+        return ResponseEntity.ok(response);
+    }
+
+    /*
+    // 2. 토큰 재발급
+    @PostMapping("/refresh")
+    public ResponseEntity<AuthResponse> refresh(@RequestBody String refreshToken) {
+        // AuthService에 refresh 로직 추가 필요
+        return ResponseEntity.ok().build();
+    }
+
+    // 3. 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String accessToken) {
+        // AuthService에 logout 로직 추가 필요
+        return ResponseEntity.ok().build();
+    }
+    */
+}

--- a/src/main/java/com/symteo/domain/auth/controller/DevAuthController.java
+++ b/src/main/java/com/symteo/domain/auth/controller/DevAuthController.java
@@ -1,0 +1,41 @@
+package com.symteo.domain.auth.controller;
+
+import com.symteo.domain.auth.dto.AuthResponse;
+import com.symteo.domain.user.enums.Role;
+import com.symteo.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+//swagger에서 임시 토큰 발급을 위한 파일
+@RestController
+@RequestMapping("/api/v1/dev")
+@RequiredArgsConstructor
+public class DevAuthController {
+
+    private final JwtProvider jwtProvider;
+
+    // URL: GET /api/v1/dev/login?userId=1
+    @GetMapping("/login")
+    public ResponseEntity<AuthResponse> devLogin(@RequestParam Long userId) {
+
+        // 1. 토큰 생성
+        String accessToken = jwtProvider.createAccessToken(userId, Role.USER);
+        String refreshToken = jwtProvider.createRefreshToken(userId);
+
+        // 2. 응답 생성 (변경된 DTO 순서에 맞춰서 5개 값을 넣어줍니다)
+        // 순서: accessToken, refreshToken, isNewMember, userId, nickname
+        AuthResponse response = new AuthResponse(
+                accessToken,
+                refreshToken,
+                false,          // isNewMember: 개발용이니까 그냥 false(기존회원)로 고정
+                userId,         // userId
+                "Developer"     // nickname: 개발자용 임의 닉네임
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/symteo/domain/auth/dto/AuthResponse.java
+++ b/src/main/java/com/symteo/domain/auth/dto/AuthResponse.java
@@ -1,0 +1,18 @@
+package com.symteo.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor //DevAuthController 관련 설정
+@AllArgsConstructor  //DevAuthController 관련 설정
+public class AuthResponse {
+    private String accessToken;
+    private String refreshToken;
+    private boolean isRegistered; // true: 정회원, false: 닉네임 설정 필요
+    private Long userId;
+    private String nickname;
+}

--- a/src/main/java/com/symteo/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/symteo/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.symteo.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+    private String token; // 프론트에서 주는 소셜 Access Token
+}

--- a/src/main/java/com/symteo/domain/auth/repository/UserTokenRepository.java
+++ b/src/main/java/com/symteo/domain/auth/repository/UserTokenRepository.java
@@ -1,0 +1,12 @@
+package com.symteo.domain.auth.repository;
+
+import com.symteo.domain.user.entity.UserTokens;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserTokenRepository extends JpaRepository<UserTokens, Long> {
+    Optional<UserTokens> findByRefreshToken(String refreshToken);
+    // 특정 유저의 토큰 삭제 (로그아웃 등)
+    void deleteByUser_Id(Long userId);
+}

--- a/src/main/java/com/symteo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/symteo/domain/auth/service/AuthService.java
@@ -1,0 +1,76 @@
+package com.symteo.domain.auth.service;
+
+import com.symteo.domain.auth.dto.AuthResponse;
+import com.symteo.domain.auth.repository.UserTokenRepository;
+import com.symteo.domain.user.entity.User;
+import com.symteo.domain.user.entity.UserTokens;
+import com.symteo.domain.user.repository.UserRepository;
+import com.symteo.global.jwt.JwtProvider;
+import com.symteo.global.oauth.info.SocialUserInfo;
+import com.symteo.global.oauth.service.SocialLoadStrategy;
+import org.springframework.transaction.annotation.Transactional;
+import com.symteo.domain.user.enums.Role;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final SocialLoadStrategy socialLoadStrategy;
+    private final UserRepository userRepository;
+    private final UserTokenRepository userTokenRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public AuthResponse login(String provider, String accessToken) {
+        // 1. 소셜 서버에서 사용자 정보(식별자) 가져오기
+        SocialUserInfo socialUser = socialLoadStrategy.getSocialInfo(provider, accessToken);
+
+        // 2. DB 조회 (없으면 회원가입, 있으면 로그인)
+        User user = userRepository.findBySocialTypeAndSocialId(socialUser.getSocialType(), socialUser.getSocialId())
+                .orElseGet(() -> registerUser(socialUser));
+
+        // 3. 앱 전용 토큰(JWT) 발급
+        String appAccessToken = jwtProvider.createAccessToken(user.getId(), user.getRole());
+        String appRefreshToken = jwtProvider.createRefreshToken(user.getId());
+
+        // 4. Refresh Token 저장
+        saveRefreshToken(user, appRefreshToken);
+
+        // 5. 응답 생성
+        return AuthResponse.builder()
+                .accessToken(appAccessToken)
+                .refreshToken(appRefreshToken)
+                .isRegistered(user.getRole() == Role.USER) // USER면 가입완료, GUEST면 미완료
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .build();
+    }
+
+    // 신규 유저 저장 (GUEST 권한)
+    private User registerUser(SocialUserInfo socialUser) {
+        User newUser = User.builder()
+                .socialType(socialUser.getSocialType())
+                .socialId(socialUser.getSocialId())
+                .role(Role.GUEST) // 초기엔 GUEST
+                .build();
+        return userRepository.save(newUser);
+    }
+
+    // 리프레시 토큰 저장
+    private void saveRefreshToken(User user, String refreshToken) {
+        // 만료 시간은 보통 2주 (14일)
+        LocalDateTime expiresAt = LocalDateTime.now().plusWeeks(2);
+
+        UserTokens token = UserTokens.builder()
+                .user(user)
+                .refreshToken(refreshToken)
+                .expiresAt(expiresAt)
+                .build();
+        userTokenRepository.save(token);
+    }
+}

--- a/src/main/java/com/symteo/domain/user/entity/User.java
+++ b/src/main/java/com/symteo/domain/user/entity/User.java
@@ -1,0 +1,67 @@
+package com.symteo.domain.user.entity;
+
+import com.symteo.domain.user.enums.Role;
+import com.symteo.domain.user.enums.SocialType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import jakarta.persistence.Id;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "Users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "users_id") // ERD의 PK 컬럼명 반영
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_type", nullable = false, length = 20)
+    private SocialType socialType;
+
+    @Column(name = "social_id", nullable = false)
+    private String socialId;
+
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "nickname", length = 10)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private Role role;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public User(SocialType socialType, String socialId, com.symteo.domain.user.enums.Role role) {
+        this.socialType = socialType;
+        this.socialId = socialId;
+        this.role = role;
+    }
+
+    // 닉네임 설정 메서드 (가입 완료 시 사용)
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+        this.role = Role.USER; // 정회원 승격
+    }
+
+}

--- a/src/main/java/com/symteo/domain/user/entity/UserTokens.java
+++ b/src/main/java/com/symteo/domain/user/entity/UserTokens.java
@@ -1,0 +1,44 @@
+package com.symteo.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "User_Tokens")
+public class UserTokens {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false) // FK 컬럼명
+    private User user;
+
+    @Column(name = "refresh_token", nullable = false, length = 512)
+    private String refreshToken;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Builder
+    public UserTokens(User user, String refreshToken, LocalDateTime expiresAt) {
+        this.user = user;
+        this.refreshToken = refreshToken;
+        this.expiresAt = expiresAt;
+    }
+
+    // 토큰 갱신 메서드 (RTR)
+    public void updateRefreshToken(String newRefreshToken, LocalDateTime newExpiresAt) {
+        this.refreshToken = newRefreshToken;
+        this.expiresAt = newExpiresAt;
+    }
+}

--- a/src/main/java/com/symteo/domain/user/enums/Role.java
+++ b/src/main/java/com/symteo/domain/user/enums/Role.java
@@ -1,0 +1,20 @@
+package com.symteo.domain.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    // 1. 가입은 되었으나 닉네임 등 추가 정보를 입력하지 않은 상태
+    GUEST("ROLE_GUEST", "손님"),
+
+    // 2. 닉네임 등록까지 마친 정회원
+    USER("ROLE_USER", "일반 사용자"),
+
+    // 3. 관리자 (필요 시 사용)
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;   // 스프링 시큐리티에서 사용할 키 (ROLE_ 접두사 필수)
+    private final String title; // 사람이 읽기 위한 설명 (UI 표시용)
+}

--- a/src/main/java/com/symteo/domain/user/enums/SocialType.java
+++ b/src/main/java/com/symteo/domain/user/enums/SocialType.java
@@ -1,0 +1,14 @@
+package com.symteo.domain.user.enums;
+
+public enum SocialType {
+    KAKAO, NAVER, GOOGLE;
+
+    // 문자열에서 Enum으로 변환하는 메서드(API 호출용)
+    public static SocialType from(String provider) {
+        try {
+            return SocialType.valueOf(provider.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("지원하지 않는 소셜 타입입니다: " + provider);
+        }
+    }
+}

--- a/src/main/java/com/symteo/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/symteo/domain/user/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.symteo.domain.user.repository;
+
+import com.symteo.domain.user.entity.User;
+import com.symteo.domain.user.enums.SocialType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    // 소셜 타입과 소셜 ID로 유저 찾기 (로그인 핵심 쿼리)
+    Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+    // 닉네임 중복 검사
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/symteo/global/config/SecurityConfig.java
+++ b/src/main/java/com/symteo/global/config/SecurityConfig.java
@@ -1,26 +1,59 @@
 package com.symteo.global.config;
 
+import com.symteo.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                // 1. CSRF 비활성화 (API 서버이므로 필요 없음)
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
-                        .anyRequest().permitAll()  // 개발 중이므로 모든 요청 허용
-                );
+
+                // 2. Form 로그인 & HttpBasic 비활성화 (JWT 사용하므로)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                // 3. 세션 사용 안 함 (Stateless 설정)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 4. 접근 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        // (1) Swagger 및 인증 관련 API는 모두 허용
+                        .requestMatchers(
+                                "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html",
+                                "/api/v1/auth/**", "/error", "/favicon.ico"
+                        ).permitAll()
+
+                        // (2) 그 외 모든 요청은 인증 필요
+                        .anyRequest().authenticated()
+                )
+
+                // 5. JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 추가
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
+
+
+    //@Bean
+    //public BCryptPasswordEncoder bCryptPasswordEncoder(){
+    //   return new BCryptPasswordEncoder();
+    //}
 }
 

--- a/src/main/java/com/symteo/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/symteo/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.symteo.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 1. 헤더에서 토큰 추출
+        String token = jwtProvider.resolveToken(request);
+
+        // 2. 토큰 유효성 검사
+        if (token != null && jwtProvider.validateToken(token)) {
+            Long userId = jwtProvider.getUserId(token);
+
+            // 3. 인증 객체 생성 (비밀번호는 없으므로 null, 권한은 일단 빈 리스트 혹은 실제 권한 조회)
+            // 간단하게 ID만 SecurityContext에 넣음
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, new ArrayList<>());
+
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            // 4. SecurityContext에 등록 (이게 되어야 @AuthenticationPrincipal 사용 가능)
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/symteo/global/jwt/JwtProvider.java
+++ b/src/main/java/com/symteo/global/jwt/JwtProvider.java
@@ -1,0 +1,98 @@
+package com.symteo.global.jwt;
+
+import com.symteo.domain.user.enums.Role;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private Key key;
+    private final long ACCESS_TOKEN_VALID_TIME = 30 * 60 * 1000L; // 30분
+    private final long REFRESH_TOKEN_VALID_TIME = 14 * 24 * 60 * 60 * 1000L; // 14일
+
+    @PostConstruct
+    protected void init() {
+        // 0.9.1 버전용 비밀키 생성 로직
+        // secretKey를 Base64로 인코딩한 뒤 바이트 배열로 변환
+        String encodedKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+        // 알고리즘(HmacSHA256)에 맞는 키 객체 생성
+        this.key = new SecretKeySpec(encodedKey.getBytes(), SignatureAlgorithm.HS256.getJcaName());
+    }
+
+    // Access Token 생성
+    public String createAccessToken(Long userId, Role role) {
+        return createToken(userId, role, ACCESS_TOKEN_VALID_TIME);
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(Long userId) {
+        return createToken(userId, null, REFRESH_TOKEN_VALID_TIME);
+    }
+
+    private String createToken(Long userId, Role role, long validTime) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
+        if (role != null) {
+            claims.put("role", role.name());
+        }
+
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + validTime))
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+
+    // 헤더에서 토큰 추출
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(key).parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    // 토큰에서 UserId 추출
+    public Long getUserId(String token) {
+        String userId = Jwts.parser().setSigningKey(key)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+        return Long.parseLong(userId);
+    }
+}

--- a/src/main/java/com/symteo/global/oauth/exception/SocialTypeException.java
+++ b/src/main/java/com/symteo/global/oauth/exception/SocialTypeException.java
@@ -1,0 +1,4 @@
+package com.symteo.global.oauth.exception;
+
+public class SocialTypeException {
+}

--- a/src/main/java/com/symteo/global/oauth/impl/GoogleUserInfo.java
+++ b/src/main/java/com/symteo/global/oauth/impl/GoogleUserInfo.java
@@ -1,0 +1,24 @@
+package com.symteo.global.oauth.impl;
+
+import com.symteo.domain.user.enums.SocialType;
+import com.symteo.global.oauth.info.SocialUserInfo;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements SocialUserInfo {
+    private final Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getSocialId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.GOOGLE;
+    }
+}

--- a/src/main/java/com/symteo/global/oauth/impl/KakaoUserInfo.java
+++ b/src/main/java/com/symteo/global/oauth/impl/KakaoUserInfo.java
@@ -1,0 +1,24 @@
+package com.symteo.global.oauth.impl;
+
+import com.symteo.domain.user.enums.SocialType;
+import com.symteo.global.oauth.info.SocialUserInfo;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements SocialUserInfo {
+    private final Map<String, Object> attributes;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getSocialId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.KAKAO;
+    }
+}

--- a/src/main/java/com/symteo/global/oauth/impl/NaverUserInfo.java
+++ b/src/main/java/com/symteo/global/oauth/impl/NaverUserInfo.java
@@ -1,0 +1,29 @@
+package com.symteo.global.oauth.impl;
+
+import com.symteo.domain.user.enums.SocialType;
+import com.symteo.global.oauth.info.SocialUserInfo;
+
+import java.util.Map;
+
+public class NaverUserInfo implements SocialUserInfo {
+    private final Map<String, Object> attributes; // 전체 응답
+    private final Map<String, Object> response;   // "response" 내부
+
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.response = (Map<String, Object>) attributes.get("response");
+    }
+
+    @Override
+    public String getSocialId() {
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("id");
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.NAVER;
+    }
+}

--- a/src/main/java/com/symteo/global/oauth/info/SocialUserInfo.java
+++ b/src/main/java/com/symteo/global/oauth/info/SocialUserInfo.java
@@ -1,0 +1,8 @@
+package com.symteo.global.oauth.info;
+
+import com.symteo.domain.user.enums.SocialType;
+
+public interface SocialUserInfo {
+    String getSocialId();
+    SocialType getSocialType();
+}

--- a/src/main/java/com/symteo/global/oauth/service/SocialLoadStrategy.java
+++ b/src/main/java/com/symteo/global/oauth/service/SocialLoadStrategy.java
@@ -1,0 +1,65 @@
+package com.symteo.global.oauth.service;
+
+import com.symteo.domain.user.enums.SocialType;
+import com.symteo.global.oauth.impl.GoogleUserInfo;
+import com.symteo.global.oauth.impl.KakaoUserInfo;
+import com.symteo.global.oauth.impl.NaverUserInfo;
+import com.symteo.global.oauth.info.SocialUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SocialLoadStrategy {
+    private final WebClient webClient = WebClient.create();
+
+    @Value("${oauth.kakao.user-info-uri}")
+    private String kakaoUserInfoUri;
+
+    @Value("${oauth.naver.user-info-uri}")
+    private String naverUserInfoUri;
+
+    @Value("${oauth.google.user-info-uri}")
+    private String googleUserInfoUri;
+
+    public SocialUserInfo getSocialInfo(String providerName, String accessToken) {
+        SocialType socialType = SocialType.from(providerName);
+
+        return switch (socialType) {
+            case KAKAO -> getKakaoInfo(accessToken);
+            case GOOGLE -> getGoogleInfo(accessToken);
+            case NAVER -> getNaverInfo(accessToken);
+        };
+    }
+
+    private SocialUserInfo getKakaoInfo(String accessToken) {
+        Map<String, Object> attributes = callSocialApi(kakaoUserInfoUri, accessToken);
+        return new KakaoUserInfo(attributes);
+    }
+
+    private SocialUserInfo getGoogleInfo(String accessToken) {
+        Map<String, Object> attributes = callSocialApi(googleUserInfoUri, accessToken);
+        return new GoogleUserInfo(attributes);
+    }
+
+    private SocialUserInfo getNaverInfo(String accessToken) {
+        Map<String, Object> attributes = callSocialApi(naverUserInfoUri, accessToken);
+        return new NaverUserInfo(attributes);
+    }
+
+    private Map<String, Object> callSocialApi(String url, String accessToken) {
+        return webClient.get()
+                .uri(url)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,6 +23,17 @@ spring:
     out-of-order: false
     clean-disabled: true
 
+oauth:
+  google:
+    client-id: ${google_client_id}
+    user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+
+  naver:
+    user-info-uri: https://openapi.naver.com/v1/nid/me
+
+  kakao:
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
@@ -33,4 +44,5 @@ springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
 
-
+jwt:
+  secret: "vmfhalwtptkdgoqjfrktyjsskfdyrgnwjdqkqhdtlsfhqptwwkd" # 임의의 긴 문자열

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -64,7 +64,7 @@ CREATE TABLE `Settings` (
                             CONSTRAINT `FK_Users_TO_Settings` FOREIGN KEY (`users_id`) REFERENCES `Users` (`users_id`)
 );
 
-CREATE TABLE `UserTokens` (
+CREATE TABLE `User_Tokens` (
                               `token_id` BIGINT NOT NULL AUTO_INCREMENT,
                               `user_id` BIGINT NOT NULL,
                               `refresh_token` VARCHAR(512) NOT NULL,


### PR DESCRIPTION
## 📌 작업 개요
- google, naver, kakao 로그인 시 access token 발급

## ✅ 작업 상세 내용
- google, naver, kakao 개발자 센터 설정 및 소셜 로그인 관련 폴더(global>oauth, jwt/ domain> auth, user) 생성
- build.grade 파일 수정
-  application.yaml 파일에 jwt 및 auth 관련 코드 추가
- UserToken table 명칭 -> User_Tokens 로 바꿈

## 🔍 테스트 및 확인 사항
- 로컬 테스트 또는 API 응답 확인 
- Swagger 문서 반영 

## 📂 관련 이슈
- Close #이슈번호 또는 관련된 이슈 번호 명시

## 🙋 기타 참고 사항
- 프론트와 토큰 발급 작업 필요
- (소셜 로그인 기능 완성 전이라) swagger 테스트를 위해, userId 입력 시에 임시 토큰 발급이 가능하도록 해둠