### PR TITLE
Niicka/24/profile

### DIFF
--- a/src/main/java/com/symteo/domain/user/controller/UserController.java
+++ b/src/main/java/com/symteo/domain/user/controller/UserController.java
@@ -1,11 +1,13 @@
 package com.symteo.domain.user.controller;
 
 import com.symteo.domain.auth.dto.AuthResponse;
+import com.symteo.domain.user.dto.UpdateNicknameRequest;
+import com.symteo.domain.user.dto.UserProfileResponse;
 import com.symteo.domain.user.dto.UserSignUpRequest;
 import com.symteo.domain.user.service.UserService;
+import com.symteo.global.ApiPayload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,44 +20,38 @@ public class UserController {
 
     // 닉네임 중복 확인 API
     @GetMapping("/check-nickname")
-    public ResponseEntity<?> checkNickname(@RequestParam String nickname) {
-        try {
-            boolean isDuplicated = userService.checkNicknameDuplication(nickname);
-
-            // isDuplicated가 true면 중복(사용불가), false면 사용 가능
-            return ResponseEntity.ok(new NicknameCheckResponse(isDuplicated));
-
-        } catch (IllegalArgumentException e) {
-            // 유효성(글자수, 특수문자 등) 실패 시 400 에러 리턴
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    public ApiResponse<NicknameCheckResponse> checkNickname(@RequestParam String nickname) {
+        boolean isDuplicated = userService.checkNicknameDuplication(nickname);
+        return ApiResponse.onSuccess(new NicknameCheckResponse(isDuplicated));
     }
 
 
     // 회원가입 완료 (닉네임 설정) API
     @PostMapping("/signup")
-    public ResponseEntity<?> completeSignUp(
+    public ApiResponse<AuthResponse> completeSignUp(
             @AuthenticationPrincipal Long userId,
             @RequestBody UserSignUpRequest request
     ) {
         log.info("회원가입 완료 요청 - UserId: {}, Nickname: {}", userId, request.getNickname());
+        AuthResponse response = userService.completeSignUp(userId, request);
+        return ApiResponse.onSuccess(response);
+    }
 
-        try {
-            // userId가 null일 경우 - 토큰 오류
-            if (userId == null) {
-                return ResponseEntity.status(401).body("인증 정보가 유효하지 않습니다.");
-            }
+    // MY 심터 프로필 정보 조회 API (프로필 사진, 닉네임)
+    @GetMapping("/profile")
+    public ApiResponse<UserProfileResponse> getUserProfile(@AuthenticationPrincipal Long userId) {
+        UserProfileResponse response = userService.getUserProfile(userId);
+        return ApiResponse.onSuccess(response);
+    }
 
-            AuthResponse response = userService.completeSignUp(userId, request);
-            return ResponseEntity.ok(response);
-
-        } catch (IllegalArgumentException e) {
-            // 중복된 닉네임이거나 유효하지 않은 입력일 경우
-            return ResponseEntity.badRequest().body(e.getMessage());
-        } catch (Exception e) {
-            log.error("회원가입 처리 중 에러 발생", e);
-            return ResponseEntity.internalServerError().body("서버 에러가 발생했습니다.");
-        }
+    // 닉네임 수정 API
+    @PatchMapping("/nickname")
+    public ApiResponse<UserProfileResponse> updateNickname(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UpdateNicknameRequest request
+    ) {
+        UserProfileResponse response = userService.updateNickname(userId, request);
+        return ApiResponse.onSuccess(response);
     }
 
     // response DTO

--- a/src/main/java/com/symteo/domain/user/dto/UpdateNicknameRequest.java
+++ b/src/main/java/com/symteo/domain/user/dto/UpdateNicknameRequest.java
@@ -1,0 +1,9 @@
+package com.symteo.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateNicknameRequest {
+    private String nickname;
+}
+

--- a/src/main/java/com/symteo/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/symteo/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,16 @@
+package com.symteo.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserProfileResponse(
+    String nickname,
+    String profileImageUrl
+) {
+    public static UserProfileResponse of(String nickname, String profileImageUrl) {
+        return UserProfileResponse.builder()
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/symteo/domain/user/service/UserService.java
+++ b/src/main/java/com/symteo/domain/user/service/UserService.java
@@ -1,12 +1,15 @@
 package com.symteo.domain.user.service;
-
 import com.symteo.domain.auth.dto.AuthResponse;
 import com.symteo.domain.auth.repository.UserTokenRepository;
+import com.symteo.domain.user.dto.UpdateNicknameRequest;
+import com.symteo.domain.user.dto.UserProfileResponse;
 import com.symteo.domain.user.dto.UserSignUpRequest;
 import com.symteo.domain.user.entity.User;
 import com.symteo.domain.user.entity.UserTokens;
 import com.symteo.domain.user.repository.UserRepository;
 
+import com.symteo.global.ApiPayload.exception.GeneralException;
+import com.symteo.global.ApiPayload.status.ErrorStatus;
 import com.symteo.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,20 +33,16 @@ public class UserService {
     public boolean checkNicknameDuplication(String nickname) {
         // 1. 빈 값 체크(사용자가 값을 입력을 하지 않은 경우)
         if (nickname == null || nickname.trim().isEmpty()) {
-            throw new IllegalArgumentException("닉네임을 입력해주세요.");
+            throw new GeneralException(ErrorStatus._NICKNAME_EMPTY);
         }
 
         // 2. 유효성 검사 (정규식)
         if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
-            throw new IllegalArgumentException("닉네임은 특수문자를 제외한 3~10자리여야 합니다.");
+            throw new GeneralException(ErrorStatus._NICKNAME_INVALID);
         }
 
         // 3. 중복 검사 (DB에 이미 저장된 닉네임인 경우)
-        if (userRepository.existsByNickname(nickname)) {
-            return true; // 중복됨 (닉네임 사용 불가)
-        }
-
-        return false; // 중복 안 됨 (닉네임 사용 가능)
+        return userRepository.existsByNickname(nickname);
     }
 
     // 회원가입 완료(닉네임 등록 + Role 변경 + 새 토큰 발급)
@@ -52,11 +51,11 @@ public class UserService {
 
         // 1. 유저 조회
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
         // 2. 닉네임 중복 재검사 (안전장치)
         if (checkNicknameDuplication(request.getNickname())) {
-            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+            throw new GeneralException(ErrorStatus._NICKNAME_DUPLICATED);
         }
 
         // 3. 닉네임 업데이트 및 권한 승격 (GUEST -> USER)
@@ -92,5 +91,31 @@ public class UserService {
 
         // 저장
         userTokenRepository.save(newToken);
+    }
+
+    // MY 심터 프로필 정보 조회 (프로필 사진, 닉네임)
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        // 프로필 이미지는 현재 null (추후 구현)
+        return UserProfileResponse.of(user.getNickname(), null);
+    }
+
+    // 닉네임 수정
+    @Transactional
+    public UserProfileResponse updateNickname(Long userId, UpdateNicknameRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        // 닉네임 중복 검사
+        if (checkNicknameDuplication(request.getNickname())) {
+            throw new GeneralException(ErrorStatus._NICKNAME_DUPLICATED);
+        }
+
+        // 닉네임 업데이트
+        user.authorizeUser(request.getNickname());
+
+        return UserProfileResponse.of(user.getNickname(), null);
     }
 }

--- a/src/main/java/com/symteo/global/ApiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/symteo/global/ApiPayload/status/ErrorStatus.java
@@ -25,11 +25,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _USER_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_MISSION404", "진행 중인 미션이 아닙니다."),
     _IMAGE_URL_MISSING(HttpStatus.BAD_REQUEST, "MISSION400", "선택된 이미지가 없습니다."),
 
-    // Member 없음 오류
-    _MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "사용자가 없습니다.");
-
-    // Member 없음 오류
-//    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다");
+    // User 오류
+    _MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "사용자가 없습니다."),
+    _NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "USER409", "이미 사용 중인 닉네임입니다."),
+    _NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "USER400", "닉네임은 특수문자를 제외한 3~10자리여야 합니다."),
+    _NICKNAME_EMPTY(HttpStatus.BAD_REQUEST, "USER400", "닉네임을 입력해주세요.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 📌 작업 개요
- MY 심터 화면의 사용자 프로필 정보 조회 및 닉네임 수정 API 구현

## ✅ 작업 상세 내용

1. 엔티티 및 Repository 생성
2. API 구현
- GET /api/v1/users/profile - MY 심터 프로필 정보 조회 (닉네임, 프로필 사진)
- PATCH /api/v1/users/nickname- 닉네임 수정 (중복 검사 포함)

## 🔍 테스트 및 확인 사항
- GET /api/v1/users/profile - 프로필 조회
Response: { "nickname": "홍따오기", "profileImageUrl": null }
- PATCH /api/v1/users/nickname - 닉네임 수정
Request: { "nickname": "새닉네임" }
중복 검사 로직 포함
유효성 검사 (3~10자, 특수문자 제외) 
- GET /api/v1/users/check-nickname?nickname=테스트 - 닉네임 중복 확인
Response: { "isDuplicated": true/false }

## 📂 관련 이슈
-#24인데.... 아직 할일 많아서 close x

## 🙋 기타 참고 사항
- IllegalArgumentException → GeneralException 사용
- 닉네임 중복 검사 로직 checkNicknameDuplication() 메서드가 true를 반환하면 중복 (회원가입 API와 닉네임 수정 API 모두에서 재사용)