### PR TITLE
feat: MY 심터 User API 구현 (settings)

### DIFF
--- a/src/main/java/com/symteo/domain/user/controller/UserController.java
+++ b/src/main/java/com/symteo/domain/user/controller/UserController.java
@@ -2,7 +2,9 @@ package com.symteo.domain.user.controller;
 
 import com.symteo.domain.auth.dto.AuthResponse;
 import com.symteo.domain.user.dto.UpdateNicknameRequest;
+import com.symteo.domain.user.dto.UpdateUserSettingsRequest;
 import com.symteo.domain.user.dto.UserProfileResponse;
+import com.symteo.domain.user.dto.UserSettingsResponse;
 import com.symteo.domain.user.dto.UserSignUpRequest;
 import com.symteo.domain.user.service.UserService;
 import com.symteo.global.ApiPayload.ApiResponse;
@@ -51,6 +53,23 @@ public class UserController {
             @RequestBody UpdateNicknameRequest request
     ) {
         UserProfileResponse response = userService.updateNickname(userId, request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    // 환경설정 토글 상태 및 앱 버전 조회 API
+    @GetMapping("/settings")
+    public ApiResponse<UserSettingsResponse> getUserSettings(@AuthenticationPrincipal Long userId) {
+        UserSettingsResponse response = userService.getUserSettings(userId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    // 환경설정 업데이트 API
+    @PatchMapping("/settings")
+    public ApiResponse<UserSettingsResponse> updateUserSettings(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UpdateUserSettingsRequest request
+    ) {
+        UserSettingsResponse response = userService.updateUserSettings(userId, request);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/symteo/domain/user/dto/UpdateUserSettingsRequest.java
+++ b/src/main/java/com/symteo/domain/user/dto/UpdateUserSettingsRequest.java
@@ -1,0 +1,12 @@
+package com.symteo.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateUserSettingsRequest {
+    private Boolean isCheerMsgOn;
+    private Boolean isAnalysisReadyOn;
+    private Boolean isMonthlyReportOn;
+    private Boolean isLockEnabled;
+}
+

--- a/src/main/java/com/symteo/domain/user/dto/UserSettingsResponse.java
+++ b/src/main/java/com/symteo/domain/user/dto/UserSettingsResponse.java
@@ -1,0 +1,34 @@
+package com.symteo.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserSettingsResponse(
+    // 환경 설정 - 알림 설정
+    Boolean isCheerMsgOn, // 응원 메세지
+    Boolean isAnalysisReadyOn, // 검사지 분석 완료
+    Boolean isMonthlyReportOn, // 월간 진단 알림
+
+    // 사용자 설정 - 잠금 설정
+    Boolean isLockEnabled, // 잠금 설정
+
+    // 앱 정보
+    String appVersion // 앱 버전
+) {
+    public static UserSettingsResponse of(
+        Boolean isCheerMsgOn,
+        Boolean isAnalysisReadyOn,
+        Boolean isMonthlyReportOn,
+        Boolean isLockEnabled,
+        String appVersion
+    ) {
+        return UserSettingsResponse.builder()
+                .isCheerMsgOn(isCheerMsgOn)
+                .isAnalysisReadyOn(isAnalysisReadyOn)
+                .isMonthlyReportOn(isMonthlyReportOn)
+                .isLockEnabled(isLockEnabled)
+                .appVersion(appVersion)
+                .build();
+    }
+}
+

--- a/src/main/java/com/symteo/domain/user/entity/UserSettings.java
+++ b/src/main/java/com/symteo/domain/user/entity/UserSettings.java
@@ -1,0 +1,62 @@
+package com.symteo.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "Settings")
+public class UserSettings {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "settings_id")
+    private Long settingsId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "is_cheer_msg_on", nullable = false)
+    private Boolean isCheerMsgOn = true;
+
+    @Column(name = "is_analysis_ready_on", nullable = false)
+    private Boolean isAnalysisReadyOn = true;
+
+    @Column(name = "is_monthly_report_on", nullable = false)
+    private Boolean isMonthlyReportOn = true;
+
+    @Column(name = "is_lock_enabled", nullable = false)
+    private Boolean isLockEnabled = false;
+
+    @Builder
+    public UserSettings(User user) {
+        this.user = user;
+        this.isCheerMsgOn = true;
+        this.isAnalysisReadyOn = true;
+        this.isMonthlyReportOn = true;
+        this.isLockEnabled = false;
+    }
+
+    // 토글 상태 업데이트 메서드
+    public void updateCheerMsg(Boolean isOn) {
+        this.isCheerMsgOn = isOn;
+    }
+
+    public void updateAnalysisReady(Boolean isOn) {
+        this.isAnalysisReadyOn = isOn;
+    }
+
+    public void updateMonthlyReport(Boolean isOn) {
+        this.isMonthlyReportOn = isOn;
+    }
+
+    public void updateLockEnabled(Boolean isEnabled) {
+        this.isLockEnabled = isEnabled;
+    }
+}
+

--- a/src/main/java/com/symteo/domain/user/repository/UserSettingsRepository.java
+++ b/src/main/java/com/symteo/domain/user/repository/UserSettingsRepository.java
@@ -1,0 +1,13 @@
+package com.symteo.domain.user.repository;
+
+import com.symteo.domain.user.entity.User;
+import com.symteo.domain.user.entity.UserSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserSettingsRepository extends JpaRepository<UserSettings, Long> {
+    Optional<UserSettings> findByUser(User user);
+    Optional<UserSettings> findByUser_Id(Long userId);
+}
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,3 +63,8 @@ springdoc:
 
 jwt:
   secret: "vmfhalwtptkdgoqjfrktyjsskfdyrgnwjdqkqhdtlsfhqptwwkd" # 임의의 긴 문자열
+
+# 앱 버전 정보
+app:
+  version: 0.0.1
+


### PR DESCRIPTION
## 📌 작업 개요
- MY 심터 환경설정 토글 상태 및 앱 버전 조회/수정 API 구현

## ✅ 작업 상세 내용
- GET /api/v1/users/settings - 환경설정 조회 (토글 상태 + 앱 버전)
- PATCH /api/v1/users/settings - 환경설정 수정

알림 설정 토글 상태 관리 (응원 메시지, 검사지 분석 완료, 월간 진단 알림)
잠금 설정 토글 상태 관리
앱 버전 정보 조회
UserSettings가 없으면 자동으로 기본값 생성
토글 상태 개별 업데이트 가능 (null 체크)

## 🔍 테스트 및 확인 사항
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공하였습니다.",
  "result": {
    "isCheerMsgOn": true,
    "isAnalysisReadyOn": true,
    "isMonthlyReportOn": true,
    "isLockEnabled": false,
    "appVersion": "0.0.1"
  }
}


## 📂 관련 이슈
- Close #31 

## 🙋 기타 참고 사항
- UserSettings 자동 생성 로직
환경설정 조회 시 UserSettings가 없으면 기본값으로 자동 생성
모든 토글은 기본적으로 true (알림 켜짐), 잠금만 false
- 토글 상태 개별 업데이트
Request에서 null이 아닌 필드만 업데이트
일부 설정만 변경하고 싶을 때 유용
- 앱 버전 관리
application.yaml에서 app.version 값 관리
@ Value 어노테이션으로 주입받아 사용