### PR TITLE
MY 심터 AI 상담사 설정 조회/수정 API 구현(#32)

### DIFF
--- a/src/main/java/com/symteo/domain/user/controller/UserController.java
+++ b/src/main/java/com/symteo/domain/user/controller/UserController.java
@@ -1,11 +1,7 @@
 package com.symteo.domain.user.controller;
 
 import com.symteo.global.auth.dto.AuthResponse;
-import com.symteo.domain.user.dto.UpdateNicknameRequest;
-import com.symteo.domain.user.dto.UpdateUserSettingsRequest;
-import com.symteo.domain.user.dto.UserProfileResponse;
-import com.symteo.domain.user.dto.UserSettingsResponse;
-import com.symteo.domain.user.dto.UserSignUpRequest;
+import com.symteo.domain.user.dto.*;
 import com.symteo.domain.user.service.UserService;
 import com.symteo.global.ApiPayload.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -69,6 +65,25 @@ public class UserController {
             @RequestBody UpdateUserSettingsRequest request
     ) {
         UserSettingsResponse response = userService.updateUserSettings(userId, request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    // AI 상담사 설정 조회 API
+    @GetMapping("/counselor-settings")
+    public ApiResponse<CounselorSettingsResponse> getCounselorSettings(
+            @AuthenticationPrincipal Long userId
+    ) {
+        CounselorSettingsResponse response = userService.getCounselorSettings(userId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    // AI 상담사 설정 수정 API
+    @PatchMapping("/counselor-settings")
+    public ApiResponse<CounselorSettingsResponse> updateCounselorSettings(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UpdateCounselorSettingsRequest request
+    ) {
+        CounselorSettingsResponse response = userService.updateCounselorSettings(userId, request);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/symteo/domain/user/dto/CounselorSettingsResponse.java
+++ b/src/main/java/com/symteo/domain/user/dto/CounselorSettingsResponse.java
@@ -1,0 +1,30 @@
+package com.symteo.domain.user.dto;
+
+import com.symteo.domain.counsel.enums.Answer_Format;
+import com.symteo.domain.counsel.enums.Atmosphere;
+import com.symteo.domain.counsel.enums.Counselor_Role;
+import com.symteo.domain.counsel.enums.Support_Style;
+import lombok.Builder;
+
+@Builder
+public record CounselorSettingsResponse(
+    Atmosphere atmosphere,         // 분위기 (emotional, warm, calm)
+    Support_Style supportStyle,     // 지지 스타일 (empathic, solution, fact)
+    Counselor_Role roleCounselor,   // 상담사 역할 (counselor, friend, mental_coatch)
+    Answer_Format answerFormat      // 답변 형식 (situational, short_format, long_format)
+) {
+    public static CounselorSettingsResponse of(
+        Atmosphere atmosphere,
+        Support_Style supportStyle,
+        Counselor_Role roleCounselor,
+        Answer_Format answerFormat
+    ) {
+        return CounselorSettingsResponse.builder()
+                .atmosphere(atmosphere)
+                .supportStyle(supportStyle)
+                .roleCounselor(roleCounselor)
+                .answerFormat(answerFormat)
+                .build();
+    }
+}
+

--- a/src/main/java/com/symteo/domain/user/dto/UpdateCounselorSettingsRequest.java
+++ b/src/main/java/com/symteo/domain/user/dto/UpdateCounselorSettingsRequest.java
@@ -1,0 +1,20 @@
+package com.symteo.domain.user.dto;
+
+import com.symteo.domain.counsel.enums.Answer_Format;
+import com.symteo.domain.counsel.enums.Atmosphere;
+import com.symteo.domain.counsel.enums.Counselor_Role;
+import com.symteo.domain.counsel.enums.Support_Style;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateCounselorSettingsRequest {
+    private Atmosphere atmosphere;
+    private Support_Style supportStyle;
+    private Counselor_Role roleCounselor;
+    private Answer_Format answerFormat;
+}
+

--- a/src/main/java/com/symteo/global/ApiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/symteo/global/ApiPayload/status/ErrorStatus.java
@@ -41,6 +41,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // AI 상담사 중복 오류
     COUNSELOR_ALREADY_EXISTS(HttpStatus.CONFLICT, "COUNSELOR409", "이미 상담사 설정이 존재합니다."),
+    COUNSELOR_NOT_FOUND(HttpStatus.NOT_FOUND, "COUNSELOR404", "상담사 설정을 찾을 수 없습니다."),
     _WITHDRAWAL_RESTRICTION(HttpStatus.FORBIDDEN, "USER403", "탈퇴 후 7일간 재가입할 수 없습니다."),
     _TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "토큰을 찾을 수 없습니다."),
 


### PR DESCRIPTION
## 📌 작업 개요
- MY 심터 화면에서 AI 상담사 설정을 조회하고 수정할 수 있는 API 구현

## ✅ 작업 상세 내용
- MY 심터 조회: GET /api/v1/users/counselor-settings 
- MY 심터 수정: PATCH /api/v1/users/counselor-settings 

## 🔍 테스트 및 확인 사항
- 조회 API: 온보딩에서 설정한 상담사 설정 조회 가능
- 수정 API: null이 아닌 필드만 선택적으로 업데이트
- 에러 처리: 상담사 설정이 없을 경우 COUNSELOR_NOT_FOUND 응답

## 📂 관련 이슈
- Close #32 

## 🙋 기타 참고 사항
- Builder 패턴으로 새 객체 생성 후 저장 ->CounselorSettings 엔티티에 update 메서드 추가 (고도화시...)