### PR TITLE
feat: MY 심터 미션 수정 API 구현 (#33)

### DIFF
--- a/src/main/java/com/symteo/domain/todayMission/repository/UserMissionRepository.java
+++ b/src/main/java/com/symteo/domain/todayMission/repository/UserMissionRepository.java
@@ -24,4 +24,7 @@ public interface UserMissionRepository extends JpaRepository<UserMissions, Long>
     // MY 심터 미션 이력 조회
     List<UserMissions> findByUserAndIsCompletedTrueOrderByCompletedAtDesc(User user);
 
+    // 특정 미션 조회 (유저 확인)
+    Optional<UserMissions> findByUserMissionIdAndUser(Long userMissionId, User user);
+
 }

--- a/src/main/java/com/symteo/domain/user/controller/UserController.java
+++ b/src/main/java/com/symteo/domain/user/controller/UserController.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -103,6 +106,18 @@ public class UserController {
             @PathVariable Long userMissionId
     ) {
         MissionHistoryResponse.MissionDetailResponse response = userService.getMissionDetail(userId, userMissionId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    // 미션 내용 및 이미지 수정 API (MY 심터)
+    @PatchMapping("/missions/history/{userMissionId}")
+    public ApiResponse<UpdateMissionResponse> updateMission(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long userMissionId,
+            @RequestPart(required = false) UpdateMissionRequest request,
+            @RequestPart(required = false) List<MultipartFile> images
+    ) {
+        UpdateMissionResponse response = userService.updateMission(userId, userMissionId, request, images);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/symteo/domain/user/dto/UpdateMissionRequest.java
+++ b/src/main/java/com/symteo/domain/user/dto/UpdateMissionRequest.java
@@ -1,0 +1,9 @@
+package com.symteo.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateMissionRequest {
+    private String contents; // 수정할 일기 내용
+}
+

--- a/src/main/java/com/symteo/domain/user/dto/UpdateMissionResponse.java
+++ b/src/main/java/com/symteo/domain/user/dto/UpdateMissionResponse.java
@@ -1,0 +1,14 @@
+package com.symteo.domain.user.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record UpdateMissionResponse(
+        Long userMissionId,
+        String draftContents,
+        List<String> imageUrls
+) {
+}
+

--- a/src/main/java/com/symteo/global/ApiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/symteo/global/ApiPayload/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404","오늘의 미션이 없습니다."),
     _MISSION_EXPIRED(HttpStatus.GONE, "MISSION410", "미션 기한이 만료되었습니다."),
     _USER_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_MISSION404", "진행 중인 미션이 아닙니다."),
+    _DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "DRAFT404", "작성된 내용이 없습니다."),
     _IMAGE_URL_MISSING(HttpStatus.BAD_REQUEST, "MISSION400", "선택된 이미지가 없습니다."),
     _IMAGE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "MISSION400", "이미지 업로드에 실패했습니다."),
     _MISSION_REFRESH_EXCEEDED(HttpStatus.CONFLICT, "MISSION409", "이미 새로고침했습니다."),


### PR DESCRIPTION
## 📌 작업 개요
- MY 심터에서 작성한 미션의 일기 내용과 이미지를 수정할 수 있는 API 구현

## ✅ 작업 상세 내용
- 미션 수정 요청 DTO (일기 내용)
- 미션 수정 응답 DTO (수정된 내용 + 이미지)

## 🔍 테스트 및 확인 사항
- 미션 일기 내용 수정
- 미션 이미지 수정 (복수 이미지 지원)
-  내용만, 이미지만, 또는 둘 다 수정 가능
-  기존 이미지는 삭제 후 새 이미지로 교체
-  본인이 작성한 미션만 수정 가능 (권한 체크)

## 📂 관련 이슈
- Close #34

## 🙋 기타 참고 사항
- Draft가 없는 경우 _DRAFT_NOT_FOUND 에러 반환