### PR TITLE
feat: 상담사 설정, 수정에 tone 추가

### DIFF
--- a/src/main/java/com/symteo/domain/counsel/entity/CounselorSettings.java
+++ b/src/main/java/com/symteo/domain/counsel/entity/CounselorSettings.java
@@ -41,11 +41,12 @@ public class CounselorSettings {
     @Enumerated(EnumType.STRING)
     private Tone tone;
 
-    public void update(Atmosphere atmosphere, Support_Style supportStyle, Counselor_Role roleCounselor, Answer_Format answerFormat) {
+    public void update(Atmosphere atmosphere, Support_Style supportStyle, Counselor_Role roleCounselor, Answer_Format answerFormat, Tone tone) {
         this.atmosphere = atmosphere;
         this.supportStyle = supportStyle;
         this.roleCounselor = roleCounselor;
         this.answerFormat = answerFormat;
+        this.tone = tone;
     }
 
 }

--- a/src/main/java/com/symteo/domain/counsel/service/CounselCommandServiceImpl.java
+++ b/src/main/java/com/symteo/domain/counsel/service/CounselCommandServiceImpl.java
@@ -75,7 +75,7 @@ public class CounselCommandServiceImpl implements CounselCommandService{
                         "support_style", settings.getSupportStyle(),
                         "role", settings.getRoleCounselor(),
                         "answer_format", settings.getAnswerFormat().getPromptText(),
-                        "tone", settings.getTone()
+                        "tone", settings.getTone().getPromptText()
                 ));
 
         // 3) AI 호출

--- a/src/main/java/com/symteo/domain/user/dto/CounselorSettingsResponse.java
+++ b/src/main/java/com/symteo/domain/user/dto/CounselorSettingsResponse.java
@@ -4,6 +4,7 @@ import com.symteo.domain.counsel.enums.Answer_Format;
 import com.symteo.domain.counsel.enums.Atmosphere;
 import com.symteo.domain.counsel.enums.Counselor_Role;
 import com.symteo.domain.counsel.enums.Support_Style;
+import com.symteo.domain.counsel.enums.Tone;
 import lombok.Builder;
 
 @Builder
@@ -11,19 +12,22 @@ public record CounselorSettingsResponse(
     Atmosphere atmosphere,         // 분위기 (emotional, warm, calm)
     Support_Style supportStyle,     // 지지 스타일 (empathic, solution, fact)
     Counselor_Role roleCounselor,   // 상담사 역할 (counselor, friend, mental_coatch)
-    Answer_Format answerFormat      // 답변 형식 (situational, short_format, long_format)
+    Answer_Format answerFormat,     // 답변 형식 (situational, short_format, long_format)
+    Tone tone                       // 말투 (formal, unformal)
 ) {
     public static CounselorSettingsResponse of(
         Atmosphere atmosphere,
         Support_Style supportStyle,
         Counselor_Role roleCounselor,
-        Answer_Format answerFormat
+        Answer_Format answerFormat,
+        Tone tone
     ) {
         return CounselorSettingsResponse.builder()
                 .atmosphere(atmosphere)
                 .supportStyle(supportStyle)
                 .roleCounselor(roleCounselor)
                 .answerFormat(answerFormat)
+                .tone(tone)
                 .build();
     }
 }

--- a/src/main/java/com/symteo/domain/user/dto/UpdateCounselorSettingsRequest.java
+++ b/src/main/java/com/symteo/domain/user/dto/UpdateCounselorSettingsRequest.java
@@ -4,6 +4,7 @@ import com.symteo.domain.counsel.enums.Answer_Format;
 import com.symteo.domain.counsel.enums.Atmosphere;
 import com.symteo.domain.counsel.enums.Counselor_Role;
 import com.symteo.domain.counsel.enums.Support_Style;
+import com.symteo.domain.counsel.enums.Tone;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,5 +17,6 @@ public class UpdateCounselorSettingsRequest {
     private Support_Style supportStyle;
     private Counselor_Role roleCounselor;
     private Answer_Format answerFormat;
+    private Tone tone;
 }
 

--- a/src/main/java/com/symteo/domain/user/service/UserService.java
+++ b/src/main/java/com/symteo/domain/user/service/UserService.java
@@ -214,7 +214,8 @@ public class UserService {
                 settings.getAtmosphere(),
                 settings.getSupportStyle(),
                 settings.getRoleCounselor(),
-                settings.getAnswerFormat()
+                settings.getAnswerFormat(),
+                settings.getTone()
         );
     }
 
@@ -231,7 +232,8 @@ public class UserService {
                 request.getAtmosphere() != null ? request.getAtmosphere() : settings.getAtmosphere(),
                 request.getSupportStyle() != null ? request.getSupportStyle() : settings.getSupportStyle(),
                 request.getRoleCounselor() != null ? request.getRoleCounselor() : settings.getRoleCounselor(),
-                request.getAnswerFormat() != null ? request.getAnswerFormat() : settings.getAnswerFormat()
+                request.getAnswerFormat() != null ? request.getAnswerFormat() : settings.getAnswerFormat(),
+                request.getTone() != null ? request.getTone() : settings.getTone()
         );
 
         counselorSettingRepository.save(settings);
@@ -240,7 +242,8 @@ public class UserService {
                 settings.getAtmosphere(),
                 settings.getSupportStyle(),
                 settings.getRoleCounselor(),
-                settings.getAnswerFormat()
+                settings.getAnswerFormat(),
+                settings.getTone()
         );
     }
 


### PR DESCRIPTION
## 📌 작업 개요
-  상담사 설정, 수정에 tone 빠져있는 부분 채움

## ✅ 작업 상세 내용
- Tone tone 필드 추가, of() 메서드에 tone 파라미터 추가
- update() 메서드에 tone 파라미터 추가
- getCounselorSettings(): tone 조회 추가
- updateCounselorSettings(): tone 수정 로직 추가
- 프롬프트 렌더링 시 settings.getTone().getPromptText() 사용하도록 수정

## 🔍 테스트 및 확인 사항
- 빌드성공

## 📂 관련 이슈
- Close #103 

## 🙋 기타 참고 사항