### PR TITLE
fix:  getPromptText() enum에서 호출하도록 설정

### DIFF
--- a/src/main/java/com/symteo/domain/counsel/service/CounselCommandServiceImpl.java
+++ b/src/main/java/com/symteo/domain/counsel/service/CounselCommandServiceImpl.java
@@ -71,9 +71,9 @@ public class CounselCommandServiceImpl implements CounselCommandService{
         // 2-1) 프롬프트 로딩 => Resources 폴더에 존재
         String systemText = new SystemPromptTemplate(askCounselPrompt)
                 .render(Map.of(
-                        "atmosphere", settings.getAtmosphere(),
-                        "support_style", settings.getSupportStyle(),
-                        "role", settings.getRoleCounselor(),
+                        "atmosphere", settings.getAtmosphere().getPromptText(),
+                        "support_style", settings.getSupportStyle().getPromptText(),
+                        "role", settings.getRoleCounselor().getPromptText(),
                         "answer_format", settings.getAnswerFormat().getPromptText(),
                         "tone", settings.getTone().getPromptText()
                 ));


### PR DESCRIPTION
## 📌 작업 개요
- .getPromptText() 추가

## ✅ 작업 상세 내용
- enum 자체만 넘기면 enum 이름만 넘어가고 프롬프트 지침 전달이 안돼서 .getPromptText()를 호출하도록 수정

## 🔍 테스트 및 확인 사항
- 로컬 테스트 또는 API 응답 확인 내용
- Swagger 문서 반영 여부 등

## 📂 관련 이슈
- Close #이슈번호 또는 관련된 이슈 번호 명시

## 🙋 기타 참고 사항
- 코드 리뷰 시 봐줬으면 하는 포인트
- TODO 또는 추후 리팩토링 예정 내용 등